### PR TITLE
Add snapshotsCommitted/partitionsCommitted to GaaSJobObservabilityEvent DatasetMetric

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSJobObservabilityEvent.avsc
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/avro/GaaSJobObservabilityEvent.avsc
@@ -264,6 +264,18 @@
                 "type": ["null","string"],
                 "doc": "Whether the dataset passed the overall data quality check",
                 "default": null
+              },
+              {
+                "name": "snapshotsCommitted",
+                "type": "long",
+                "doc": "Number of table snapshots committed for the dataset in this run (e.g. Iceberg snapshot-replication commits), -1 if unsupported/unknown by the writer",
+                "default": -1
+              },
+              {
+                "name": "partitionsCommitted",
+                "type": "long",
+                "doc": "Number of partitions committed for the dataset in this run, -1 if unsupported/unknown by the writer",
+                "default": -1
               }
             ]
           }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/DatasetTaskSummary.java
@@ -42,11 +42,16 @@ public class DatasetTaskSummary {
   @NonNull private long bytesWritten;
   @NonNull private boolean successfullyCommitted;
   @NonNull private String dataQualityStatus;
+  // NOTE: intentionally NOT @NonNull so the 5-arg @RequiredArgsConstructor stays intact for native
+  // Gobblin call sites (AbstractJobLauncher). Populated via reflection during JSON deserialization
+  // of events that carry them (e.g. DDM Iceberg snapshot replication); default -1 = unsupported/unknown.
+  private long snapshotsCommitted = -1L;
+  private long partitionsCommitted = -1L;
 
   /**
    * Convert a {@link DatasetTaskSummary} to a {@link DatasetMetric}.
    */
   public static DatasetMetric toDatasetMetric(DatasetTaskSummary datasetTaskSummary) {
-    return new DatasetMetric(datasetTaskSummary.getDatasetUrn(), datasetTaskSummary.getBytesWritten(), datasetTaskSummary.getRecordsWritten(), datasetTaskSummary.isSuccessfullyCommitted(), datasetTaskSummary.getDataQualityStatus());
+    return new DatasetMetric(datasetTaskSummary.getDatasetUrn(), datasetTaskSummary.getBytesWritten(), datasetTaskSummary.getRecordsWritten(), datasetTaskSummary.isSuccessfullyCommitted(), datasetTaskSummary.getDataQualityStatus(), datasetTaskSummary.getSnapshotsCommitted(), datasetTaskSummary.getPartitionsCommitted());
   }
 }


### PR DESCRIPTION
BUG=[ETL-XXXXX](https://linkedin.atlassian.net/browse/ETL-XXXXX)

# Problem & Solution Overview
DDM Iceberg snapshot replication reports per-run `snapshotsCommitted` and `partitionsCommitted`, but `GaaSJobObservabilityEvent.DatasetMetric` had no field to carry them, so they never reached the observability event.

- `GaaSJobObservabilityEvent.avsc`: add `snapshotsCommitted` + `partitionsCommitted` (long, default `-1` = unsupported/unknown) to the `DatasetMetric` record.
- `DatasetTaskSummary`: add the two counts as **non-`@NonNull`** long fields so the existing 5-arg `@RequiredArgsConstructor` (used by `AbstractJobLauncher`) is preserved; they populate via JSON deserialization for events that supply them. `toDatasetMetric` maps them onto the regenerated 7-arg `DatasetMetric`.

Backward compatible: default `-1` for producers/events that do not set them; native Gobblin call sites unchanged.

# Testing Done
- `./gradlew :gobblin-metrics-libs:gobblin-metrics-base:generateAvro` regenerates `DatasetMetric` with the 7-arg ctor + both fields.
- `./gradlew :gobblin-runtime:compileJava` passes.
- Companion ddm-executor change threads the two values onto the `DatasetTaskSummary` JSON (verified via `DDMEventContextTest`).