### PR TITLE
Surface per-dataset copy metrics on the job-status JobStatistics REST API

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/JobStatistics.pdl
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-api/src/main/pegasus/org/apache/gobblin/service/JobStatistics.pdl
@@ -29,4 +29,34 @@ record JobStatistics {
    * estimate of time left until job completion
    */
   estimatedSecondsToCompletion: long
+
+  /**
+   * Number of bytes written/copied for the dataset in this job execution.
+   * Optional; populated by writers that report byte counts (e.g. DDM file/blob replication), -1 if unsupported.
+   */
+  bytesWritten: optional long
+
+  /**
+   * Number of records (or files, for file/blob copies) written for the dataset in this job execution.
+   * Optional; -1 if unsupported by the writer.
+   */
+  recordsWritten: optional long
+
+  /**
+   * Number of files committed for the dataset in this job execution.
+   * Optional; populated by file/blob writers (e.g. DDM Iceberg replication), absent otherwise.
+   */
+  filesCommitted: optional long
+
+  /**
+   * Number of table snapshots committed for the dataset in this job execution (e.g. Iceberg snapshot-replication commits).
+   * Optional; absent when the writer does not commit snapshots.
+   */
+  snapshotsCommitted: optional long
+
+  /**
+   * Number of partitions committed for the dataset in this job execution.
+   * Optional; absent when the writer does not report partition commits.
+   */
+  partitionsCommitted: optional long
 }

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/org/apache/gobblin/service/FlowExecutionResource.java
@@ -184,17 +184,35 @@ public class FlowExecutionResource extends ComplexKeyResourceTemplate<FlowStatus
       Long timeLeft = estimateCopyTimeLeft(queriedJobStatus.getLastProgressEventTime(), queriedJobStatus.getStartTime(),
           queriedJobStatus.getProgressPercentage());
 
+      JobStatistics jobStatistics = new JobStatistics()
+          .setExecutionStartTime(queriedJobStatus.getStartTime())
+          .setExecutionEndTime(queriedJobStatus.getEndTime())
+          .setProcessedCount(queriedJobStatus.getProcessedCount())
+          .setJobProgress(queriedJobStatus.getProgressPercentage())
+          .setEstimatedSecondsToCompletion(timeLeft);
+      // Optional per-dataset copy metrics (e.g. DDM file/blob replication); set only when reported (>= 0).
+      if (queriedJobStatus.getBytesWritten() >= 0) {
+        jobStatistics.setBytesWritten(queriedJobStatus.getBytesWritten());
+      }
+      if (queriedJobStatus.getRecordsWritten() >= 0) {
+        jobStatistics.setRecordsWritten(queriedJobStatus.getRecordsWritten());
+      }
+      if (queriedJobStatus.getFilesCommitted() >= 0) {
+        jobStatistics.setFilesCommitted(queriedJobStatus.getFilesCommitted());
+      }
+      if (queriedJobStatus.getSnapshotsCommitted() >= 0) {
+        jobStatistics.setSnapshotsCommitted(queriedJobStatus.getSnapshotsCommitted());
+      }
+      if (queriedJobStatus.getPartitionsCommitted() >= 0) {
+        jobStatistics.setPartitionsCommitted(queriedJobStatus.getPartitionsCommitted());
+      }
+
       jobStatus.setFlowId(flowId)
           .setJobId(new JobId()
               .setJobName(queriedJobStatus.getJobName())
               .setJobGroup(queriedJobStatus.getJobGroup()))
           .setJobTag(queriedJobStatus.getJobTag(), SetMode.IGNORE_NULL)
-          .setExecutionStatistics(new JobStatistics()
-              .setExecutionStartTime(queriedJobStatus.getStartTime())
-              .setExecutionEndTime(queriedJobStatus.getEndTime())
-              .setProcessedCount(queriedJobStatus.getProcessedCount())
-              .setJobProgress(queriedJobStatus.getProgressPercentage())
-              .setEstimatedSecondsToCompletion(timeLeft))
+          .setExecutionStatistics(jobStatistics)
           .setExecutionStatus(ExecutionStatus.valueOf(queriedJobStatus.getEventName()))
           .setMessage(queriedJobStatus.getMessage())
           .setJobState(new JobState()

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatus.java
@@ -60,4 +60,11 @@ public class JobStatus {
   private final Supplier<List<Issue>> issues;
   private final int progressPercentage;
   private final long lastProgressEventTime;
+  // Optional per-dataset copy metrics surfaced on the job-status REST API (JobStatistics).
+  // -1 = unset/unsupported; populated for writers that report them (e.g. DDM file/blob replication).
+  @Builder.Default private final long bytesWritten = -1L;
+  @Builder.Default private final long recordsWritten = -1L;
+  @Builder.Default private final long filesCommitted = -1L;
+  @Builder.Default private final long snapshotsCommitted = -1L;
+  @Builder.Default private final long partitionsCommitted = -1L;
 }

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/service/monitoring/JobStatusRetriever.java
@@ -60,6 +60,15 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
   public static final String EVENT_NAME_FIELD = "eventName";
   public static final String NA_KEY = "NA";
 
+  // DDM (and other file/blob movement) writers report per-dataset copy metrics on the JobSummary
+  // GTE via these flat metadata keys; the job-status monitor persists them into the job state, and
+  // they are surfaced here on the JobStatistics REST surface. -1 = absent/unsupported.
+  public static final String BYTES_WRITTEN_FIELD = "ddm.bytesCopied";
+  public static final String RECORDS_WRITTEN_FIELD = "ddm.rowsCopied";
+  public static final String FILES_COMMITTED_FIELD = "ddm.filesCommitted";
+  public static final String SNAPSHOTS_COMMITTED_FIELD = "ddm.snapshotsCommitted";
+  public static final String PARTITIONS_COMMITTED_FIELD = "ddm.partitionsCommitted";
+
   @Getter
   protected final MetricContext metricContext;
 
@@ -156,13 +165,20 @@ public abstract class JobStatusRetriever implements LatestFlowExecutionIdTracker
     boolean shouldRetry = Boolean.parseBoolean(jobState.getProp(TimingEvent.FlowEventConstants.SHOULD_RETRY_FIELD, "false"));
     int progressPercentage = jobState.getPropAsInt(TimingEvent.JOB_COMPLETION_PERCENTAGE, 0);
     long lastProgressEventTime = jobState.getPropAsLong(TimingEvent.JOB_LAST_PROGRESS_EVENT_TIME, 0);
+    long bytesWritten = jobState.getPropAsLong(BYTES_WRITTEN_FIELD, -1L);
+    long recordsWritten = jobState.getPropAsLong(RECORDS_WRITTEN_FIELD, -1L);
+    long filesCommitted = jobState.getPropAsLong(FILES_COMMITTED_FIELD, -1L);
+    long snapshotsCommitted = jobState.getPropAsLong(SNAPSHOTS_COMMITTED_FIELD, -1L);
+    long partitionsCommitted = jobState.getPropAsLong(PARTITIONS_COMMITTED_FIELD, -1L);
 
     return JobStatus.builder().flowName(flowName).flowGroup(flowGroup).flowExecutionId(flowExecutionId).jobName(jobName)
         .jobGroup(jobGroup).jobTag(jobTag).jobExecutionId(jobExecutionId).eventName(eventName).lowWatermark(lowWatermark)
         .highWatermark(highWatermark).orchestratedTime(orchestratedTime).startTime(startTime).endTime(endTime)
         .message(message).processedCount(processedCount).maxAttempts(maxAttempts).currentAttempts(currentAttempts)
         .currentGeneration(currentGeneration).shouldRetry(shouldRetry).progressPercentage(progressPercentage)
-        .lastProgressEventTime(lastProgressEventTime);
+        .lastProgressEventTime(lastProgressEventTime)
+        .bytesWritten(bytesWritten).recordsWritten(recordsWritten).filesCommitted(filesCommitted)
+        .snapshotsCommitted(snapshotsCommitted).partitionsCommitted(partitionsCommitted);
   }
 
   protected static final String getFlowGroup(State jobState) {


### PR DESCRIPTION
BUG=[ETL-XXXXX](https://linkedin.atlassian.net/browse/ETL-XXXXX)

# Problem & Solution Overview
DDM copy metrics reach `GaaSJobObservabilityEvent` but are not exposed on the job-status REST API, so callers of `FlowExecution`/job-status cannot see bytes/files/snapshots/partitions committed.

- `JobStatistics.pdl` (executionStatistics): add optional `bytesWritten`, `recordsWritten`, `filesCommitted`, `snapshotsCommitted`, `partitionsCommitted`.
- `JobStatusRetriever`: read them from the flat `ddm.*` copy-metric keys the JobSummary GTE persists into the job state (`-1` = absent/unsupported).
- `FlowExecutionResource`: set each on `JobStatistics` only when reported (>= 0), so non-DDM jobs'  responses are unchanged.

# Testing Done
- `./gradlew ...:gobblin-flow-config-service-api:generateDataTemplate` regenerates `JobStatistics` with the new setters.
- `./gradlew :gobblin-runtime:compileJava :gobblin-restli:gobblin-flow-config-service:gobblin-flow-config-service-server:compileJava` passes.